### PR TITLE
Improve mobile chat layout and conversation ordering

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,4 +1,29 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
 /* Basic styling for the chat interface. The colour palette loosely follows the dark blue and orange theme from NubaCom. */
+:root {
+  --font-primary: 'Inter', 'Google Sans', 'Product Sans', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  --composer-border: #e5e7eb;
+  --composer-bg: #ffffff;
+  --composer-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  --composer-text: #0f172a;
+  --composer-muted: #6b7280;
+  --accent-dark: #0d274d;
+  --surface-muted: #f5f7fa;
+}
+
+@media (max-width: 600px) {
+  .composer-menu {
+    min-width: 200px;
+  }
+
+  .composer-submenu {
+    position: static;
+    margin-top: 8px;
+    left: auto;
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  }
+}
 html,
 body {
   /* Ensure the root elements occupy the full viewport.  Using both
@@ -15,7 +40,7 @@ body {
   flex-direction: column;
   width: 100%;
   overflow: hidden;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-primary);
   background-color: #e5e9f0;
   color: #0d274d;
 }
@@ -391,106 +416,379 @@ body {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px 16px;
+  justify-content: center;
+  padding: 16px 20px;
   background-color: #ffffff;
   border-top: 1px solid #e2e8f0;
-  /* Ensure the message form respects safe area at the bottom on mobile devices */
-  padding-bottom: max(12px, env(safe-area-inset-bottom, 12px));
+  padding-bottom: max(16px, env(safe-area-inset-bottom, 16px));
 }
 
-.message-form input[type="text"] {
+.composer {
   flex: 1;
-  padding: 8px 12px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-size: 14px;
-  outline: none;
-}
-
-.message-form input[type="text"]:focus {
-  border-color: #80bdff;
-}
-
-.message-form button {
-  background-color: #0d274d;
-  color: #fff;
-  border: none;
-  padding: 8px 16px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-}
-
-.message-form button:hover {
-  background-color: #082042;
-}
-
-/* Style for model selection dropdown */
-.model-select {
-  padding: 6px 8px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-size: 14px;
-  background-color: #f9f9fb;
-  color: #333;
-  margin-left: 8px;
-}
-
-.model-select:focus {
-  outline: none;
-  border-color: #4e3c9b;
-}
-
-/* Controls for attachments and voice */
-.controls {
   display: flex;
-  gap: 6px;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--composer-border);
+  background-color: var(--composer-bg);
+  box-shadow: var(--composer-shadow);
+  color: var(--composer-text);
+  position: relative;
 }
 
-/* Generic icon button used for attachments and voice */
-.icon-btn {
-  background-color: #f5f7fa;
+.composer:focus-within {
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+  border-color: #d1d5db;
+}
+
+.composer-menu-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.composer-menu-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
   border: none;
+  background-color: var(--surface-muted);
+  color: var(--composer-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.composer-menu-button:hover,
+.composer-menu-button:focus-visible {
+  background-color: #edeff3;
+}
+
+.composer-menu-button:active {
+  transform: scale(0.96);
+}
+
+.composer-menu-button:focus-visible,
+.composer-action-button:focus-visible,
+.composer-send-button:focus-visible,
+.submenu-trigger:focus-visible,
+.composer-menu-item:focus-visible,
+.composer-submenu-item:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.composer-menu {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 0;
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 12px 0;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+  min-width: 240px;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(8px);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  z-index: 40;
+}
+
+.composer-menu.is-visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.composer-menu-item {
+  width: 100%;
+  background: none;
+  border: none;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 22px;
+  font-size: 14px;
+  color: var(--composer-text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.composer-menu-item:hover {
+  background-color: #f4f6fb;
+}
+
+.menu-icon {
+  width: 28px;
+  height: 28px;
   border-radius: 50%;
-  width: 32px;
-  height: 32px;
-  display: flex;
+  background-color: #eef2ff;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
-  padding: 6px;
+  color: var(--composer-text);
+  position: relative;
 }
 
-.icon-btn:hover {
-  background-color: #e9eef5;
+.menu-icon.clip {
+  background: #eef2ff url('icons/paperclip.png') center/14px 14px no-repeat;
 }
 
-.icon-btn img {
-  width: 18px;
-  height: 18px;
+.menu-icon.library::before,
+.menu-icon.library::after {
+  content: '';
+  position: absolute;
+  background-color: currentColor;
 }
 
-/* Send button with icon */
-.send-btn {
-  background-color: #0d274d;
+.menu-icon.library::before {
+  width: 14px;
+  height: 16px;
+  border-radius: 2px;
+  top: 5px;
+  left: 6px;
+  opacity: 0.88;
+}
+
+.menu-icon.library::after {
+  width: 12px;
+  height: 2px;
+  top: 9px;
+  left: 7px;
+  border-radius: 999px;
+  opacity: 0.6;
+}
+
+.menu-icon.model {
+  background-color: #dbeafe;
+}
+
+.menu-icon.model::before {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: #2563eb;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.has-submenu {
+  position: relative;
+}
+
+.submenu-trigger {
+  width: 100%;
+  background: none;
   border: none;
-  border-radius: 4px;
-  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0;
+  font-size: 14px;
+  color: inherit;
+  cursor: pointer;
+}
+
+.submenu-trigger .submenu-arrow {
+  margin-left: auto;
+  font-size: 18px;
+  color: var(--composer-muted);
+}
+
+.model-chip {
+  margin-left: auto;
+  margin-right: 8px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background-color: #eef2ff;
+  color: #4338ca;
+  font-size: 12px;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 72px;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-chip:empty::before {
+  content: '—';
+  color: var(--composer-muted);
+}
+
+.composer-submenu {
+  position: absolute;
+  top: -12px;
+  left: calc(100% + 12px);
+  min-width: 220px;
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 12px 0;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(8px);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  z-index: 45;
+}
+
+.has-submenu.open .composer-submenu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.composer-submenu-item {
+  width: 100%;
+  background: none;
+  border: none;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 22px;
+  font-size: 14px;
+  color: var(--composer-text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.composer-submenu-item:hover {
+  background-color: #f4f6fb;
+}
+
+.composer-submenu-item.is-active {
+  background-color: #eef2ff;
+  color: #1e3a8a;
+}
+
+.composer-submenu-empty {
+  padding: 12px 22px;
+  font-size: 13px;
+  color: var(--composer-muted);
+}
+
+.composer input[type="text"] {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 16px;
+  color: var(--composer-text);
+  min-width: 0;
+}
+
+.composer input[type="text"]::placeholder {
+  color: var(--composer-muted);
+}
+
+.composer input[type="text"]:focus {
+  outline: none;
+}
+
+.composer-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.composer-action-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background-color: var(--surface-muted);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  transition: background-color 0.2s ease;
 }
 
-.send-btn:hover {
-  background-color: #082042;
+.composer-action-button:hover {
+  background-color: #edeff3;
 }
 
-.send-btn img {
+.composer-action-button img {
   width: 18px;
   height: 18px;
-  filter: invert(1);
+  filter: brightness(0) saturate(100%) invert(18%) sepia(17%) saturate(596%) hue-rotate(182deg) brightness(90%) contrast(86%);
+}
+
+.composer-send-button {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background-color: #111827;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.composer-send-button:hover {
+  background-color: #000000;
+  transform: translateY(-1px);
+}
+
+.composer-send-button .icon-arrow {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  display: block;
+}
+
+.composer-send-button .icon-arrow::before {
+  content: '';
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  width: 2px;
+  height: 8px;
+  background-color: #ffffff;
+  transform: translateX(-50%);
+  border-radius: 999px;
+}
+
+.composer-send-button .icon-arrow::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-bottom: 6px solid #ffffff;
+}
+
+.model-select {
+  display: none;
 }
 
 /* Responsive adjustments for mobile screens */
@@ -499,6 +797,7 @@ body {
   .app {
     position: relative;
     min-height: 100dvh;
+    flex-direction: column;
   }
 
   /* Sidebar becomes overlay */
@@ -538,6 +837,7 @@ body {
   .main-area {
     width: 100%;
     margin-left: 0;
+    min-height: 100dvh;
   }
 
   /* Chat container full width on mobile */
@@ -551,6 +851,24 @@ body {
     padding: 0;
   }
 
+  .main-header {
+    position: sticky;
+    top: 0;
+    padding: 16px;
+    background: #ffffff;
+    z-index: 600;
+  }
+
+  .chat-header-avatar {
+    display: none;
+  }
+
+  .main-title {
+    justify-content: flex-start;
+    font-size: 20px;
+    text-align: left;
+  }
+
   /* Suggestions in a single column */
   .suggestions {
     display: grid;
@@ -558,6 +876,25 @@ body {
     gap: 12px;
     width: 100%;
     padding: 0 16px;
+  }
+
+  .greeting {
+    align-items: flex-start;
+    text-align: left;
+    padding: 32px 20px;
+    gap: 24px;
+  }
+
+  .greeting-avatar {
+    display: none;
+  }
+
+  .suggestion {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    text-align: left;
   }
 
   /* Let flexbox handle chat area height on mobile. It will fill available space */
@@ -574,14 +911,15 @@ body {
     height: auto;
   }
 
-  /* The message form will naturally stay at the bottom due to flexbox layout. */
+  /* The message form retains the compact pill layout on mobile. */
   .message-form {
-    /* No special positioning needed on mobile */
+    padding: 14px 16px;
   }
 
   /* Show toggle icon always on mobile */
   .toggle-sidebar {
     display: block;
+    font-size: 22px;
   }
 
   /* Adjust sizes for conversation list and inputs */
@@ -591,22 +929,45 @@ body {
 
   .chat-area {
     padding: 12px;
+    padding-bottom: 20px;
   }
 
-  .message-form input[type="text"] {
-    font-size: 14px;
+  .composer {
+    gap: 12px;
+    padding: 10px 14px;
   }
 
-  .message-form button {
-    font-size: 14px;
+  .composer input[type="text"] {
+    font-size: 15px;
+  }
+
+  .composer-menu-button,
+  .composer-action-button {
+    width: 38px;
+    height: 38px;
+  }
+
+  .composer-send-button {
+    width: 42px;
+    height: 42px;
+  }
+
+  .composer-actions {
+    gap: 10px;
+  }
+
+  .model-chip {
+    display: none;
   }
 
   /* Allow message bubbles to use more width on small screens */
   .message {
     max-width: 100%;
+    font-size: 15px;
   }
 
   .model-select {
     font-size: 14px;
+    margin-left: 0;
   }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1,29 +1,18 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+:root {
+  --font-primary: 'Poppins', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  --text-primary: #0d274d;
+  --text-muted: #5f6b7a;
+  --surface-page: #e5e9f0;
+  --surface-card: #ffffff;
+  --surface-soft: #f4f6fb;
+  --border-soft: #d9dfee;
+  --accent: #ec472c;
+  --accent-dark: #c63b23;
+}
+
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap');
 
 /* Basic styling for the chat interface. The colour palette loosely follows the dark blue and orange theme from NubaCom. */
-:root {
-  --font-primary: 'Inter', 'Google Sans', 'Product Sans', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-  --composer-border: #e5e7eb;
-  --composer-bg: #ffffff;
-  --composer-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
-  --composer-text: #0f172a;
-  --composer-muted: #6b7280;
-  --accent-dark: #0d274d;
-  --surface-muted: #f5f7fa;
-}
-
-@media (max-width: 600px) {
-  .composer-menu {
-    min-width: 200px;
-  }
-
-  .composer-submenu {
-    position: static;
-    margin-top: 8px;
-    left: auto;
-    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
-  }
-}
 html,
 body {
   /* Ensure the root elements occupy the full viewport.  Using both
@@ -41,8 +30,8 @@ body {
   width: 100%;
   overflow: hidden;
   font-family: var(--font-primary);
-  background-color: #e5e9f0;
-  color: #0d274d;
+  background-color: var(--surface-page);
+  color: var(--text-primary);
 }
 
 /* Application container */
@@ -189,6 +178,7 @@ body {
 }
 
 .toggle-sidebar {
+  display: none;
   background: none;
   border: none;
   font-size: 24px;
@@ -300,7 +290,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  background-color: #ffffff;
+  background-color: var(--surface-card);
   border: 1px solid #e2e8f0;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
   overflow: hidden;
@@ -415,334 +405,53 @@ body {
 .message-form {
   flex: 0 0 auto;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
+  gap: 12px;
   padding: 16px 20px;
-  background-color: #ffffff;
+  background-color: var(--surface-card);
   border-top: 1px solid #e2e8f0;
   padding-bottom: max(16px, env(safe-area-inset-bottom, 16px));
 }
 
-.composer {
-  flex: 1;
+.message-form-inner {
+  flex: 1 1 260px;
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 10px 16px;
-  border-radius: 999px;
-  border: 1px solid var(--composer-border);
-  background-color: var(--composer-bg);
-  box-shadow: var(--composer-shadow);
-  color: var(--composer-text);
-  position: relative;
-}
-
-.composer:focus-within {
-  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
-  border-color: #d1d5db;
-}
-
-.composer-menu-wrapper {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
-.composer-menu-button {
-  width: 40px;
-  height: 40px;
-  border-radius: 999px;
-  border: none;
-  background-color: var(--surface-muted);
-  color: var(--composer-text);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 24px;
-  font-weight: 500;
-  line-height: 1;
-  cursor: pointer;
-  transition: background-color 0.2s ease, transform 0.2s ease;
-}
-
-.composer-menu-button:hover,
-.composer-menu-button:focus-visible {
-  background-color: #edeff3;
-}
-
-.composer-menu-button:active {
-  transform: scale(0.96);
-}
-
-.composer-menu-button:focus-visible,
-.composer-action-button:focus-visible,
-.composer-send-button:focus-visible,
-.submenu-trigger:focus-visible,
-.composer-menu-item:focus-visible,
-.composer-submenu-item:focus-visible {
-  outline: 2px solid #6366f1;
-  outline-offset: 2px;
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.composer-menu {
-  position: absolute;
-  top: calc(100% + 12px);
-  left: 0;
-  background: #ffffff;
-  border-radius: 18px;
-  padding: 12px 0;
-  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
-  min-width: 240px;
-  opacity: 0;
-  visibility: hidden;
-  transform: translateY(8px);
-  transition: opacity 0.18s ease, transform 0.18s ease;
-  z-index: 40;
-}
-
-.composer-menu.is-visible {
-  opacity: 1;
-  visibility: visible;
-  transform: translateY(0);
-}
-
-.composer-menu-item {
-  width: 100%;
-  background: none;
-  border: none;
-  display: flex;
-  align-items: center;
+  flex-wrap: wrap;
   gap: 12px;
-  padding: 10px 22px;
-  font-size: 14px;
-  color: var(--composer-text);
-  cursor: pointer;
-  text-align: left;
-}
-
-.composer-menu-item:hover {
-  background-color: #f4f6fb;
-}
-
-.menu-icon {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background-color: #eef2ff;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--composer-text);
-  position: relative;
-}
-
-.menu-icon.clip {
-  background: #eef2ff url('icons/paperclip.png') center/14px 14px no-repeat;
-}
-
-.menu-icon.library::before,
-.menu-icon.library::after {
-  content: '';
-  position: absolute;
-  background-color: currentColor;
-}
-
-.menu-icon.library::before {
-  width: 14px;
-  height: 16px;
-  border-radius: 2px;
-  top: 5px;
-  left: 6px;
-  opacity: 0.88;
-}
-
-.menu-icon.library::after {
-  width: 12px;
-  height: 2px;
-  top: 9px;
-  left: 7px;
+  padding: 8px 14px;
+  background-color: var(--surface-soft);
+  border: 1px solid var(--border-soft);
   border-radius: 999px;
-  opacity: 0.6;
+  box-shadow: 0 6px 16px rgba(13, 39, 77, 0.08);
 }
 
-.menu-icon.model {
-  background-color: #dbeafe;
-}
-
-.menu-icon.model::before {
-  content: '';
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background-color: #2563eb;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-
-.has-submenu {
-  position: relative;
-}
-
-.submenu-trigger {
-  width: 100%;
-  background: none;
-  border: none;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 0;
-  font-size: 14px;
-  color: inherit;
-  cursor: pointer;
-}
-
-.submenu-trigger .submenu-arrow {
-  margin-left: auto;
-  font-size: 18px;
-  color: var(--composer-muted);
-}
-
-.model-chip {
-  margin-left: auto;
-  margin-right: 8px;
-  padding: 2px 10px;
-  border-radius: 999px;
-  background-color: #eef2ff;
-  color: #4338ca;
-  font-size: 12px;
-  font-weight: 500;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 72px;
-  max-width: 140px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.model-chip:empty::before {
-  content: '—';
-  color: var(--composer-muted);
-}
-
-.composer-submenu {
-  position: absolute;
-  top: -12px;
-  left: calc(100% + 12px);
-  min-width: 220px;
-  background: #ffffff;
-  border-radius: 18px;
-  padding: 12px 0;
-  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
-  opacity: 0;
-  visibility: hidden;
-  transform: translateY(8px);
-  transition: opacity 0.18s ease, transform 0.18s ease;
-  z-index: 45;
-}
-
-.has-submenu.open .composer-submenu {
-  opacity: 1;
-  visibility: visible;
-  transform: translateY(0);
-}
-
-.composer-submenu-item {
-  width: 100%;
-  background: none;
-  border: none;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 22px;
-  font-size: 14px;
-  color: var(--composer-text);
-  cursor: pointer;
-  text-align: left;
-}
-
-.composer-submenu-item:hover {
-  background-color: #f4f6fb;
-}
-
-.composer-submenu-item.is-active {
-  background-color: #eef2ff;
-  color: #1e3a8a;
-}
-
-.composer-submenu-empty {
-  padding: 12px 22px;
-  font-size: 13px;
-  color: var(--composer-muted);
-}
-
-.composer input[type="text"] {
-  flex: 1;
+.message-form input[type="text"] {
+  flex: 1 1 auto;
   border: none;
   background: transparent;
-  font-size: 16px;
-  color: var(--composer-text);
+  font-size: 15px;
+  color: var(--text-primary);
+  line-height: 1.5;
   min-width: 0;
 }
 
-.composer input[type="text"]::placeholder {
-  color: var(--composer-muted);
+.message-form input[type="text"]::placeholder {
+  color: var(--text-muted);
 }
 
-.composer input[type="text"]:focus {
+.message-form input[type="text"]:focus {
   outline: none;
 }
 
-.composer-actions {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.composer-action-button {
-  width: 40px;
-  height: 40px;
+.control-btn {
+  flex: 0 0 auto;
+  width: 38px;
+  height: 38px;
   border-radius: 50%;
-  border: none;
-  background-color: var(--surface-muted);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-}
-
-.composer-action-button:hover {
-  background-color: #edeff3;
-}
-
-.composer-action-button img {
-  width: 18px;
-  height: 18px;
-  filter: brightness(0) saturate(100%) invert(18%) sepia(17%) saturate(596%) hue-rotate(182deg) brightness(90%) contrast(86%);
-}
-
-.composer-send-button {
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  border: none;
-  background-color: #111827;
+  border: 1px solid var(--border-soft);
+  background-color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -750,45 +459,67 @@ body {
   transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
-.composer-send-button:hover {
-  background-color: #000000;
-  transform: translateY(-1px);
+.control-btn:hover,
+.control-btn:focus-visible {
+  background-color: var(--surface-soft);
 }
 
-.composer-send-button .icon-arrow {
-  position: relative;
-  width: 14px;
-  height: 14px;
-  display: block;
+.control-btn:active {
+  transform: scale(0.96);
 }
 
-.composer-send-button .icon-arrow::before {
-  content: '';
-  position: absolute;
-  bottom: 2px;
-  left: 50%;
-  width: 2px;
-  height: 8px;
-  background-color: #ffffff;
-  transform: translateX(-50%);
+.control-btn img {
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+}
+
+.send-btn {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: none;
   border-radius: 999px;
+  padding: 0 20px;
+  height: 40px;
+  background-color: var(--accent);
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
-.composer-send-button .icon-arrow::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 0;
-  height: 0;
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-bottom: 6px solid #ffffff;
+.send-btn:hover {
+  background-color: var(--accent-dark);
+}
+
+.send-btn:active {
+  transform: translateY(1px);
+}
+
+.send-btn img {
+  width: 16px;
+  height: 16px;
+  filter: invert(1);
 }
 
 .model-select {
-  display: none;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  padding: 8px 16px;
+  font-size: 14px;
+  background-color: var(--surface-soft);
+  color: var(--text-primary);
+  min-width: 160px;
+  appearance: none;
+}
+
+.model-select:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(236, 71, 44, 0.25);
 }
 
 /* Responsive adjustments for mobile screens */
@@ -797,7 +528,6 @@ body {
   .app {
     position: relative;
     min-height: 100dvh;
-    flex-direction: column;
   }
 
   /* Sidebar becomes overlay */
@@ -837,7 +567,6 @@ body {
   .main-area {
     width: 100%;
     margin-left: 0;
-    min-height: 100dvh;
   }
 
   /* Chat container full width on mobile */
@@ -851,24 +580,6 @@ body {
     padding: 0;
   }
 
-  .main-header {
-    position: sticky;
-    top: 0;
-    padding: 16px;
-    background: #ffffff;
-    z-index: 600;
-  }
-
-  .chat-header-avatar {
-    display: none;
-  }
-
-  .main-title {
-    justify-content: flex-start;
-    font-size: 20px;
-    text-align: left;
-  }
-
   /* Suggestions in a single column */
   .suggestions {
     display: grid;
@@ -876,25 +587,6 @@ body {
     gap: 12px;
     width: 100%;
     padding: 0 16px;
-  }
-
-  .greeting {
-    align-items: flex-start;
-    text-align: left;
-    padding: 32px 20px;
-    gap: 24px;
-  }
-
-  .greeting-avatar {
-    display: none;
-  }
-
-  .suggestion {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    text-align: left;
   }
 
   /* Let flexbox handle chat area height on mobile. It will fill available space */
@@ -911,63 +603,48 @@ body {
     height: auto;
   }
 
-  /* The message form retains the compact pill layout on mobile. */
-  .message-form {
+  .main-header {
+    position: sticky;
+    top: 0;
+    z-index: 20;
     padding: 14px 16px;
-  }
-
-  /* Show toggle icon always on mobile */
-  .toggle-sidebar {
-    display: block;
-    font-size: 22px;
-  }
-
-  /* Adjust sizes for conversation list and inputs */
-  .conversation-list li {
-    font-size: 14px;
+    background-color: var(--surface-card);
   }
 
   .chat-area {
     padding: 12px;
-    padding-bottom: 20px;
   }
 
-  .composer {
-    gap: 12px;
-    padding: 10px 14px;
+  .message-form {
+    padding: 14px 16px;
+    gap: 10px;
+    flex-direction: column;
+    align-items: stretch;
   }
 
-  .composer input[type="text"] {
-    font-size: 15px;
+  .toggle-sidebar {
+    display: block;
   }
 
-  .composer-menu-button,
-  .composer-action-button {
-    width: 38px;
-    height: 38px;
-  }
-
-  .composer-send-button {
-    width: 42px;
-    height: 42px;
-  }
-
-  .composer-actions {
+  .message-form-inner {
+    width: 100%;
     gap: 10px;
   }
 
-  .model-chip {
-    display: none;
+  .control-btn {
+    width: 34px;
+    height: 34px;
   }
 
-  /* Allow message bubbles to use more width on small screens */
-  .message {
-    max-width: 100%;
-    font-size: 15px;
+  .send-btn {
+    justify-content: center;
+    width: 100%;
+    flex-basis: 100%;
+    padding: 0 18px;
   }
 
   .model-select {
-    font-size: 14px;
-    margin-left: 0;
+    width: 100%;
+    flex-basis: 100%;
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -54,44 +54,22 @@
                     <!-- Messages will appear here -->
                 </div>
                 <!-- Message form sits inside chat container so it stays anchored at bottom -->
-                <form id="message-form" class="message-form">
-                    <div class="composer" role="group" aria-label="Enviar mensaje">
-                        <div class="composer-menu-wrapper">
-                            <button type="button" id="composer-menu-button" class="composer-menu-button" aria-haspopup="true" aria-expanded="false">
-                                <span aria-hidden="true">+</span>
-                                <span class="sr-only">Abrir opciones adicionales</span>
-                            </button>
-                            <div id="composer-menu" class="composer-menu" role="menu" aria-labelledby="composer-menu-button">
-                                <button type="button" id="upload-btn" class="composer-menu-item" role="menuitem">
-                                    <span class="menu-icon clip" aria-hidden="true"></span>
-                                    <span>Agregar fotos y archivos</span>
-                                </button>
-                                <div id="model-menu-container" class="composer-menu-item has-submenu" role="none">
-                                    <button type="button" id="model-menu-trigger" class="submenu-trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">
-                                        <span class="menu-icon library" aria-hidden="true"></span>
-                                        <span>Modelos disponibles</span>
-                                        <span id="current-model-label" class="model-chip"></span>
-                                        <span class="submenu-arrow" aria-hidden="true">›</span>
-                                    </button>
-                                    <div id="model-menu" class="composer-submenu" role="menu">
-                                        <div id="model-menu-list"></div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                <form id="message-form" class="message-form" autocomplete="off">
+                    <div class="message-form-inner">
+                        <button type="button" id="upload-btn" title="Adjuntar archivo" class="control-btn">
+                            <img src="{{ url_for('static', filename='icons/paperclip.png') }}" alt="Adjuntar" />
+                        </button>
                         <input id="message-input" type="text" placeholder="Escribe un mensaje…" autocomplete="off" />
-                        <div class="composer-actions">
-                            <button type="button" id="voice-btn" class="composer-action-button" title="Usar voz">
-                                <img src="{{ url_for('static', filename='icons/microphone.png') }}" alt="Voz" />
-                            </button>
-                            <button type="submit" class="composer-send-button" title="Enviar">
-                                <span class="icon-arrow" aria-hidden="true"></span>
-                                <span class="sr-only">Enviar mensaje</span>
-                            </button>
-                        </div>
+                        <button type="button" id="voice-btn" title="Usar voz" class="control-btn">
+                            <img src="{{ url_for('static', filename='icons/microphone.png') }}" alt="Voz" />
+                        </button>
+                        <button type="submit" class="send-btn">
+                            <span>Enviar</span>
+                            <img src="{{ url_for('static', filename='icons/send.png') }}" alt="Enviar" />
+                        </button>
                     </div>
+                    <select id="model-select" class="model-select"></select>
                     <input id="file-input" type="file" multiple hidden />
-                    <select id="model-select" class="model-select" hidden></select>
                 </form>
             </div>
         </main>

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,14 +55,43 @@
                 </div>
                 <!-- Message form sits inside chat container so it stays anchored at bottom -->
                 <form id="message-form" class="message-form">
-                    <div class="controls">
-                        <button type="button" id="upload-btn" title="Adjuntar archivo" class="icon-btn"><img src="{{ url_for('static', filename='icons/paperclip.png') }}" alt="Adjuntar" /></button>
-                        <button type="button" id="voice-btn" title="Usar voz" class="icon-btn"><img src="{{ url_for('static', filename='icons/microphone.png') }}" alt="Voz" /></button>
+                    <div class="composer" role="group" aria-label="Enviar mensaje">
+                        <div class="composer-menu-wrapper">
+                            <button type="button" id="composer-menu-button" class="composer-menu-button" aria-haspopup="true" aria-expanded="false">
+                                <span aria-hidden="true">+</span>
+                                <span class="sr-only">Abrir opciones adicionales</span>
+                            </button>
+                            <div id="composer-menu" class="composer-menu" role="menu" aria-labelledby="composer-menu-button">
+                                <button type="button" id="upload-btn" class="composer-menu-item" role="menuitem">
+                                    <span class="menu-icon clip" aria-hidden="true"></span>
+                                    <span>Agregar fotos y archivos</span>
+                                </button>
+                                <div id="model-menu-container" class="composer-menu-item has-submenu" role="none">
+                                    <button type="button" id="model-menu-trigger" class="submenu-trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">
+                                        <span class="menu-icon library" aria-hidden="true"></span>
+                                        <span>Modelos disponibles</span>
+                                        <span id="current-model-label" class="model-chip"></span>
+                                        <span class="submenu-arrow" aria-hidden="true">›</span>
+                                    </button>
+                                    <div id="model-menu" class="composer-submenu" role="menu">
+                                        <div id="model-menu-list"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <input id="message-input" type="text" placeholder="Escribe un mensaje…" autocomplete="off" />
+                        <div class="composer-actions">
+                            <button type="button" id="voice-btn" class="composer-action-button" title="Usar voz">
+                                <img src="{{ url_for('static', filename='icons/microphone.png') }}" alt="Voz" />
+                            </button>
+                            <button type="submit" class="composer-send-button" title="Enviar">
+                                <span class="icon-arrow" aria-hidden="true"></span>
+                                <span class="sr-only">Enviar mensaje</span>
+                            </button>
+                        </div>
                     </div>
-                    <input id="message-input" type="text" placeholder="Escribe un mensaje…" autocomplete="off" />
-                    <select id="model-select" class="model-select"></select>
-                    <button type="submit" class="send-btn"><img src="{{ url_for('static', filename='icons/send.png') }}" alt="Enviar" /></button>
-                    <input id="file-input" type="file" multiple style="display: none;" />
+                    <input id="file-input" type="file" multiple hidden />
+                    <select id="model-select" class="model-select" hidden></select>
                 </form>
             </div>
         </main>


### PR DESCRIPTION
## Summary
- refine the mobile layout with column flow, sticky header, and responsive greeting/suggestion styling
- rework the message composer into the pill-style menu from the mockup, exposing attachment/model dropdowns and a high-contrast send action that stays visible on phones while adopting the Google Sans-style typography across the interface
- show the most recent conversations at the top of the sidebar while keeping the active chat selection stable

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_b_68e1707d46a48330aa4c9b3e584882fb